### PR TITLE
Fix hook memory leak in MRFI by tracking and exposing RemovableHandle references

### DIFF
--- a/mrfi/mrfi.py
+++ b/mrfi/mrfi.py
@@ -517,6 +517,8 @@ class MRFI:
     """MRFI core object, a wrapper of network module."""
     def __init__(self, model: nn.Module, config: Union[str, EasyConfig]) -> None:   
         self.model = model
+        self._hook_handles = []
+        self._closed = False
         assert not hasattr(model, 'FI_config'), 'This model instance is used twice for MRFI, please create a new.'
 
         if isinstance(config, EasyConfig):
@@ -544,8 +546,27 @@ class MRFI:
 
     def __add_hooks(self):
         for _, module in self.model.named_modules():
-            module.register_forward_pre_hook(lambda mod, input: _pre_hook_func(mod.FI_config, mod, input))
-            module.register_forward_hook(lambda mod, input, output: _after_hook_func(mod.FI_config, mod, input, output))
+            self._hook_handles.append(
+                module.register_forward_pre_hook(lambda mod, input: _pre_hook_func(mod.FI_config, mod, input))
+            )
+            self._hook_handles.append(
+                module.register_forward_hook(lambda mod, input, output: _after_hook_func(mod.FI_config, mod, input, output))
+            )
+
+    def remove_hooks(self):
+        """Remove all PyTorch hooks registered by this MRFI wrapper."""
+        while self._hook_handles:
+            self._hook_handles.pop().remove()
+
+    def close(self):
+        """Remove MRFI instrumentation from the wrapped model."""
+        if self._closed:
+            return
+        self.remove_hooks()
+        for module in self.model.modules():
+            if hasattr(module, 'FI_config'):
+                delattr(module, 'FI_config')
+        self._closed = True
 
     def __empty_configtree(self, module: torch.nn.Module):
         curdict = {


### PR DESCRIPTION
This pull request fixes a memory leak that occurs when `MRFI` is instantiated multiple times over a fault injection campaign. The main theme is: making MRFI hooks explicitly managed so they can be properly released.

**Root cause:**
`__add_hooks` registered forward pre-hooks and forward hooks via `register_forward_pre_hook` / `register_forward_hook`, but the returned `RemovableHandle` objects were discarded. PyTorch keeps hooks alive as long as their handle exists, meaning every `MRFI` instantiation accumulated closures (including references to `FI_config` and internal state) that were never freed, even after the `MRFI` object itself was deleted. Over a long campaign this causes progressive GPU/CPU memory exhaustion.

**Changes in `mrfi.py`:**
* Introduced `_hook_handles` (list) and `_closed` (bool) instance attributes, initialized in `__init__` before `__add_hooks` is called.
* Modified `__add_hooks` to append every `RemovableHandle` returned by `register_forward_pre_hook` and `register_forward_hook` to `_hook_handles`, instead of discarding them.
* Added `remove_hooks()`: iterates `_hook_handles` and calls `.remove()` on each handle, then clears the list.
* Added `close()`: calls `remove_hooks()`, then removes the `FI_config` attribute from every submodule via `module.modules()`, and sets `_closed = True` to prevent double-closing. This fully detaches MRFI instrumentation from the underlying model, allowing the same model instance to be safely re-wrapped in a subsequent `MRFI` instantiation.

Tests are passing with `pytest --cov=mrfi`